### PR TITLE
fix: add https repository url (unblock 2.0 publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@automatons/validator",
   "version": "1.0.186",
+  "repository": "https://github.com/openapi-automatons/validator.git",
   "author": "tanmen <yt.prog@gmail.com>",
   "license": "MIT",
   "packageManager": "yarn@1.22.22",


### PR DESCRIPTION
## Problem
On the previous (re-run) attempt semantic-release reported *"the local branch main is behind the remote one, therefore a new version won't be published"* — an artifact of re-running a stale workflow run.

## Fix
Add the HTTPS `repository` field (was missing) and merge to produce a fresh release run at the current `main` tip, so semantic-release publishes 2.0.0.