### PR TITLE
docs: fix usage example, note ESM-only / Node >= 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 The validator of openapi schema.
 
+Since v2 this package is **ESM-only** and requires **Node.js >= 22**.
+
 ## Usage
 
 ```typescript
 import {validator} from "@automatons/validator";
-import {readSync} from "fs";
+import {readFileSync} from "node:fs";
 
-const result = validator(readSync('path/to/openapi.json'))
+const result = await validator(JSON.parse(readFileSync("path/to/openapi.json", "utf-8")));
+// result.valid: boolean, result.errors: { keyword, rule, location }[]
 ```


### PR DESCRIPTION
The usage example referenced a non-existent `readSync` and passed a raw buffer; validator takes a parsed object and returns a Promise. Fix the example and document the ESM-only / Node >= 22 requirement.