### PR TITLE
feat: accept OpenAPI 3.2 documents

### DIFF
--- a/src/__tests__/examples/v3_2/server-name.json
+++ b/src/__tests__/examples/v3_2/server-name.json
@@ -1,0 +1,14 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "example",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "name": "Main",
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {}
+}

--- a/src/__tests__/validator.test.ts
+++ b/src/__tests__/validator.test.ts
@@ -1,5 +1,6 @@
 import {validator} from '../validator';
 import v3_1_webhooks from './examples/v3_1/webhooks.json';
+import v3_2_server_name from './examples/v3_2/server-name.json';
 import v3_0_api_with_examples from './examples/v3_0/api-with-examples.json';
 import v3_0_callback_example from './examples/v3_0/callback-example.json';
 import v3_0_link_example from './examples/v3_0/link-example.json';
@@ -10,6 +11,10 @@ import invalid_schema from './examples/invalid_schema.json';
 
 test('v3.1', async () => {
   const result = await validator(v3_1_webhooks);
+  expect(result.valid).toBeTruthy();
+});
+test('v3.2 server name', async () => {
+  const result = await validator(v3_2_server_name);
   expect(result.valid).toBeTruthy();
 });
 test('v3.0 api-with-examples', async () => {
@@ -38,7 +43,7 @@ test('v3.0 uspto', async () => {
 });
 test('invalid version', () => {
   expect(validator({openapi: '2.0.0'})).rejects
-    .toThrow('Not supported version.\nopenapi version 3.0.0 >= version < 3.2.0');
+    .toThrow('Not supported version.\nopenapi version 3.0.0 >= version < 3.3.0');
 });
 test('invalid schema', async () => {
   const result = await validator(invalid_schema);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,5 +1,6 @@
 import {validate as validateOpenapi30} from "@hyperjump/json-schema/openapi-3-0";
 import {validate as validateOpenapi31} from "@hyperjump/json-schema/openapi-3-1";
+import {validate as validateOpenapi32} from "@hyperjump/json-schema/openapi-3-2";
 import {BASIC} from "@hyperjump/json-schema/experimental";
 import type {Json} from "@hyperjump/json-pointer";
 
@@ -20,13 +21,14 @@ type OutputUnit = {
 const dialects = {
   "3_0": {uri: "https://spec.openapis.org/oas/3.0/schema", validate: validateOpenapi30},
   "3_1": {uri: "https://spec.openapis.org/oas/3.1/schema-base", validate: validateOpenapi31},
+  "3_2": {uri: "https://spec.openapis.org/oas/3.2/schema-base", validate: validateOpenapi32},
 } as const;
 
 export const validator = async (openapi: {openapi: string; [key: string]: unknown}) => {
   const version = openapi.openapi.split(".").slice(0, 2).join("_");
   const dialect = dialects[version as keyof typeof dialects];
   if (!dialect) {
-    throw new Error("Not supported version.\nopenapi version 3.0.0 >= version < 3.2.0");
+    throw new Error("Not supported version.\nopenapi version 3.0.0 >= version < 3.3.0");
   }
   const output = (await dialect.validate(dialect.uri, openapi as unknown as Json, BASIC)) as OutputUnit;
   return {valid: output.valid, errors: errorExtractor(output)};


### PR DESCRIPTION
Registers the OpenAPI 3.2 dialect (`@hyperjump/json-schema/openapi-3-2`, `schema-base`) in the validator so documents declaring `openapi: 3.2.x` validate. Updates the unsupported-version bound message accordingly and adds a 3.2 fixture/test. 3.0/3.1 behaviour is unchanged.